### PR TITLE
initalize chgColumns as object to avoid error when table columns have…

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -6,7 +6,6 @@ var exec = require( 'child_process' ).exec;
 
 var internals =
 {
-
     _caps:
     {
 
@@ -671,7 +670,7 @@ Builder.prototype = {
         {
             var columns = [],
                 availableColumns = [],
-                chgColumns = [],
+                chgColumns = {},
                 len = 0;
 
             columns = self.diffArr( db[ 0 ][ internals.avTables[ i ] ], db[ 1 ][ internals.avTables[ i ] ] );


### PR DESCRIPTION
… the same name as Array object properties

We have a table with a "length" field that was resulting in 

```
[ERROR] RangeError: Invalid array length
    at columns (/home/will/Projects/node-ultimate-migrate/lib/builder.js:695:54)
    at ResultEmitter.<anonymous> (/home/will/Projects/node-ultimate-migrate/node_modules/umigrate-mariadb/index.js:209:29)
    at emitNone (events.js:106:13)
    at ResultEmitter.emit (events.js:208:7)
    at ResultEmitter._complete (/home/will/Projects/node-ultimate-migrate/node_modules/mariasql/lib/Client.js:699:12)
    at QueryStream.<anonymous> (/home/will/Projects/node-ultimate-migrate/node_modules/mariasql/lib/Client.js:682:10)
    at emitNone (events.js:106:13)
    at QueryStream.emit (events.js:208:7)
    at endReadableNT (_stream_readable.js:1064:12)
    at _combinedTickCallback (internal/process/next_tick.js:139:11)

```

this fixes it, thanks for the lib <3